### PR TITLE
feat(gatsby-config): Add backdrop gatsby-image

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,7 +19,8 @@ module.exports = {
               movies: ['accountFavoriteMovies']
             }
           }
-        }
+        },
+        backdrop: true,
       }
     },
     `gatsby-plugin-accessibilityjs`,


### PR DESCRIPTION
Hi 👋 
Author of the source plugin here. I somehow stumbled across your Twitter/Stream and was pleasantly surprised that you use my TMDb source plugin. I built it not long ago (so just v1.0.0 right now) and not a lot of people have used it until now I think. I skimmed through your recording and saw that you had some issues. I hope that I can improve the plugin in the future with more input from users.

Sorry, if I didn't catch anything, but here are some notes:

- `id` is a reserved word in Gatsby's GraphQL schema, so I had to rename that. I'm open to a better naming scheme though 😓 (you know, naming things is the hardest part)
- You don't get the videos from the source plugin because it didn't build that in. You see, I first query [this endpoint](https://developers.themoviedb.org/3/account/get-favorite-movies) and take the ID to [this endpoint](https://developers.themoviedb.org/3/movies/get-movie-details). As it didn't want to bloat the plugin with v1 I didn't include all the other endpoints. TMDb sadly splits up all information into so many endpoints that I just took the minimum for the beginning (as users should show which usecases are needed)
- I actually also support gatsby-image for the backdrop, hence this PR. It's behind an option (https://github.com/LekoArts/gatsby-source-tmdb#all-options). The incentive also was to not bloat the plugin for general use. I didn't want people have to wait ages to get something queried. That's why I set defaults (e.g. backdrop is `false`).
- Some of these defaults is also for e.g. `miscPopularMovies`. If I didn't set the default to `2` pages it would pull all videos of TMDb (just sorted by popularity)

So all in all, if some things are missing it's mostly because I built it around my usecase first while having in mind not to let the users face with years of waiting time.

I can certainly implement to also fetch more information about for example movies, but what the hell, just so many endpoints:

![image](https://user-images.githubusercontent.com/16143594/50740316-09274280-11ed-11e9-9d78-2fb484504658.png)

That's why a native GraphQL API of TMDb just would be the best solution...

I built an example page to showcase the plugin:
https://tmdb.lekoarts.de/ ([Source code](https://github.com/LekoArts/gatsby-source-tmdb-example))

It also uses client-side requests on the detailed pages (as I didn't include those yet into the plugin). Hover/Click the card for that.

----

So this change will make gatsby-image possible on the `backdrop_path` item. However, it will break your queries (as you see from the netlify preview) as you have to do the `childImageSharp` thingy then.